### PR TITLE
pdi-browserでコンテンツ破棄時に画像・音声を握り潰すための対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased Changes
+## 2.4.2
 * Platformインターフェースに`destroy()`を新たに追加
 
 ## 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
 
+## Unreleased Changes
+* Platformインターフェースに`destroy()`を新たに追加
+
 ## 2.4.1
 * 初期リリース

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-pdi",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~2.4.0",
-    "@akashic/amflow": "0.2.2",
-    "@akashic/playlog": "1.3.1"
+    "@akashic/amflow": "~0.2.3",
+    "@akashic/playlog": "~1.3.2"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~2.4.0",
-    "@akashic/amflow": "~0.2.3",
+    "@akashic/amflow": "~0.2.4",
     "@akashic/playlog": "~1.3.2"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~2.4.0",
-    "@akashic/amflow": "~0.2.2",
-    "@akashic/playlog": "~1.3.1"
+    "@akashic/amflow": "0.2.2",
+    "@akashic/playlog": "1.3.1"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -89,4 +89,9 @@ export interface Platform {
 	 * @param data 送信するデータ
 	 */
 	sendToExternal(playId: string, data: any): void;
+
+	/**
+	 * コンテンツ中の全リソースの削除を行う。
+	 */
+	destroy(): void;
 }

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -93,5 +93,5 @@ export interface Platform {
 	/**
 	 * コンテンツ中の全リソースの削除を行う。
 	 */
-	destroy(): void;
+	destroy?(): void;
 }

--- a/test/pdi-build-test.ts
+++ b/test/pdi-build-test.ts
@@ -155,6 +155,10 @@ class AbstractPlatform implements pdi.Platform {
 	sendToExternal(playId: string, data: any): void {
 		throw new Error("abstractPlatform.sendToExternal");
 	}
+
+	destroy(): void {
+		throw new Error("abstractPlatform#destroy is undefined");
+	}
 }
 
 // ビルドされた js ファイルで pdi を require できることを確認するために必要


### PR DESCRIPTION
### 概要
* pdi-browserでコンテンツ破棄時に画像・音声を握り潰すために、破棄用メソッドの`destroy()`をPlatformインターフェースに新設しました。

### やったこと
* Platformインターフェースに`destroy()`を新規追加
* 最新のamflowを利用するとビルドができなくなる問題があるので、暫定対応としてamflowとplaylogのバージョンを1つ前のものに固定しました