### PR TITLE
内部モジュール更新(v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.10.3
+* 内部モジュール更新
+  * @akashic/amflow@0.3.1
+  * @akashic/playlog@1.3.2
+
 ## 1.10.2
 * TypeScript のビルド結果が実行不可能になっていた問題を修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-pdi",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -42,8 +42,8 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~1.12.0",
-    "@akashic/amflow": "~0.2.2",
-    "@akashic/playlog": "~1.3.1"
+    "@akashic/amflow": "~0.3.1",
+    "@akashic/playlog": "~1.3.2"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
### 概要
* 以下のように内部モジュールを更新します
  * @akashic/amflow@0.3.1
  * @akashic/playlog@1.3.2
* 現在、最新版の@akashic/akashi-pdiと最新版の@akashic/playlogの両方に依存しているライブラリでビルドエラーが起こってしまっているので、それを解決するために早めにこの修正を入れたいです。