### PR TITLE
依存モジュール更新 (v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.17.0
+* `@akashic/amflow` と `@akashic/playlog` の minor 更新に伴うバージョンアップ
+* ddependencies の `@akashic/amflow` と `@akashic/playlog` の許容範囲を `^` に
+
 ## 1.16.0
 * `@akashic/amflow` と `@akashic/playlog` の minor 更新に伴うバージョンアップ
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@akashic/akashic-pdi",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-pdi",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "~1.14.0",
-        "@akashic/amflow": "~3.2.0",
-        "@akashic/playlog": "~3.2.0"
+        "@akashic/amflow": "^3.3.0",
+        "@akashic/playlog": "^3.3.0"
       },
       "devDependencies": {
         "@akashic/remark-preset-lint": "^0.1.2",
@@ -31,17 +31,17 @@
       "integrity": "sha512-hI/fVUs4yYWClJrYSSbW5DC5rCWQZUIlf1RSAYhye/2CIj7q5O1R0zeOpFE8pJEmYKi8AltiemDFsqAR5rMyMw=="
     },
     "node_modules/@akashic/amflow": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.2.0.tgz",
-      "integrity": "sha512-7FA3BgOouAX9o4WdcQM0kVPUKq9regdeXMiaWtw7ROz9BL8Vve+wyxmWvrE3MQEdpdMGQFb2bG9pNERiNxISNw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.3.0.tgz",
+      "integrity": "sha512-+dDBtwPfAOeslclGYYKF1yoGg+NiLnDHO3DVIGorkzSd9YLwf+LJGK4sQxRvltKBygmHmhaVrjP7de0PMA+c4Q==",
       "dependencies": {
-        "@akashic/playlog": "~3.2.0"
+        "@akashic/playlog": "~3.3.0"
       }
     },
     "node_modules/@akashic/playlog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.2.0.tgz",
-      "integrity": "sha512-J9lYTl1P1P6JmYmGMj+mGGgeRl+6o3MjO5iVqcwGSMPmBKUjxLn+BYuLfe5mreFWVobIFnmv65bzZOjzteiOzw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.3.0.tgz",
+      "integrity": "sha512-pqX31etu1H9DGvfAuW8w4TiUdcKUUoTBJQd6HF1OZWMDC2O6RSx8DTndYa4Eqr9wll+bs3aRJqUHcVdDJKWevw=="
     },
     "node_modules/@akashic/remark-preset-lint": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-pdi",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Interface definition for Akashic Platform Dependent Implementation (PDI) Layer",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~1.14.0",
-    "@akashic/amflow": "~3.2.0",
-    "@akashic/playlog": "~3.2.0"
+    "@akashic/amflow": "^3.3.0",
+    "@akashic/playlog": "^3.3.0"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
掲題通り。

併せて運用の単純化のため、 amflow/playlog の範囲を `^` に広げています。

修正自明のためセルフマージします。